### PR TITLE
Update invitation endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ The lockbox-box-service includes an invitation service that allows users to crea
 
 #### 1. Create Invitation
 
-**Endpoint:** `POST /invitation`
+**Endpoint:** `POST /invitations/new`
 
 **Headers:**
 - `Authorization`: Bearer token with valid JWT
@@ -604,7 +604,7 @@ Allows a user to accept an invitation and connect it to their account.
 
 #### 3. Refresh Invitation
 
-**Endpoint:** `POST /invitations/:inviteId/refresh`
+**Endpoint:** `PATCH /invitations/:inviteId/refresh`
 
 **Headers:**
 - `Authorization`: Bearer token with valid JWT

--- a/invitation-service/src/handlers/invitation_handlers.rs
+++ b/invitation-service/src/handlers/invitation_handlers.rs
@@ -23,7 +23,7 @@ const CODE_ALPHABET: [char; 26] = [
     'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
 ];
 
-// POST /invitation - Create a new invitation
+// POST /invitations/new - Create a new invitation
 pub async fn create_invitation<S: InvitationStore + ?Sized>(
     State(store): State<Arc<S>>,
     Extension(user_id): Extension<String>,
@@ -188,7 +188,7 @@ pub async fn publish_invitation_event_with_client(
     Ok(())
 }
 
-// POST /invitations/:inviteId/refresh - Refresh the invitation
+// PATCH /invitations/:inviteId/refresh - Refresh the invitation
 pub async fn refresh_invitation<S: InvitationStore + ?Sized>(
     State(store): State<Arc<S>>,
     Extension(user_id): Extension<String>,


### PR DESCRIPTION
## Summary
- update README to reflect new invitation endpoints
- adjust comments in invitation handlers to match new paths

## Testing
- `./run-all-tests.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6575e7d48330a0778df8b69e27df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to reflect new HTTP methods and endpoint paths for invitation service endpoints.
  - Clarified the "Create Invitation" endpoint as POST /invitations/new and the "Refresh Invitation" endpoint as PATCH /invitations/:inviteId/refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->